### PR TITLE
Adds warnings about cascading effects and permenant deletion

### DIFF
--- a/source/includes/api/_dataset.md
+++ b/source/includes/api/_dataset.md
@@ -647,9 +647,11 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset-id> \
 
 **When a dataset is deleted the user's applications that were present on the dataset will be removed from it. If this results in a dataset without applications, the dataset itself will be then deleted.**
 
-Datasets can be deleted either by ADMINS or by the MANAGERS that created them. Note that the deletion process cascades; deleting a dataset will also remove all layer, vocab, and metadata entities associated with it.
+Datasets can be deleted either by any user with role ADMIN or by the user with role MANAGER that created them. Note that the deletion process cascades; deleting a dataset will also remove all layer, vocabularies, and metadata entities associated with it.
 
-**WARNING:** Deleting a dataset removes it permanently! It is recommended that you save a local copy before doing so.
+<aside class="warning">
+Deleting a dataset removes it permanently! It is recommended that you save a local copy before doing so.
+</aside>
 
 ```shell
 curl -X DELETE https://api.resourcewatch.org/v1/dataset/<dataset-id> \

--- a/source/includes/api/_dataset.md
+++ b/source/includes/api/_dataset.md
@@ -647,6 +647,10 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset-id> \
 
 **When a dataset is deleted the user's applications that were present on the dataset will be removed from it. If this results in a dataset without applications, the dataset itself will be then deleted.**
 
+Datasets can be deleted either by ADMINS or by the MANAGERS that created them. Note that the deletion process cascades; deleting a dataset will also remove all layer, vocab, and metadata entities associated with it.
+
+**WARNING:** Deleting a dataset removes it permanently! It is recommended that you save a local copy before doing so.
+
 ```shell
 curl -X DELETE https://api.resourcewatch.org/v1/dataset/<dataset-id> \
 -H "Authorization: Bearer <your-token>"


### PR DESCRIPTION
Updates docs to include more info about the consequences of deletion. Namely that:

* datasets can be deleted either by ADMINs or by MANAGERs who created those layers/datasets
* perma-death for datasets on deletion
* deleting a dataset cascades

<img width="587" alt="screen shot 2019-02-14 at 14 55 41" src="https://user-images.githubusercontent.com/30242314/52791539-7ab6a400-3069-11e9-94ac-3fd4ed96fdea.png">
