### PR TITLE
Adds env details to docs

### DIFF
--- a/source/includes/api/_dataset.md
+++ b/source/includes/api/_dataset.md
@@ -614,6 +614,8 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset-id> \
     This is an authenticated endpoint!
 </aside>
 
+Note: When updating the `env` property of a dataset this way the change will cascade down to all associated layer and widget entities.
+
 ## Deleting a Dataset
 
 **When a dataset is deleted the user's applications that were present on the dataset will be removed from it. If this results in a dataset without applications, the dataset itself will be then deleted.**

--- a/source/includes/api/_dataset.md
+++ b/source/includes/api/_dataset.md
@@ -614,7 +614,7 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset-id> \
     This is an authenticated endpoint!
 </aside>
 
-Note: When updating the `env` property of a dataset this way the change will cascade down to all associated layer and widget entities.
+Note: When updating the `env` property of a dataset the change will cascade down to all associated layer and widget entities.
 
 ## Deleting a Dataset
 

--- a/source/includes/api/_layer.md
+++ b/source/includes/api/_layer.md
@@ -253,7 +253,7 @@ dataset           |                                                             
 protected         |                                            If it's a protected layer (not is possible to delete if it's true)                                               |   Boolean |                                 true-false |       No
 env         |                                            Environment of the Layer. Set to 'production' by default                                               |   String |                                 Valid string |       No
 
-It is possible to create a layer that has a different `env` property to it's parent dataset. 
+It is possible to create a layer that has a different `env` property to its parent dataset. 
 
 > To create a layer, you have to do a POST request with the following body:
 

--- a/source/includes/api/_layer.md
+++ b/source/includes/api/_layer.md
@@ -319,7 +319,7 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset_id>/layer/<layer
    }
 }'
 ```
-Note: it is not possible to update the `env` property of a layer this way. If you wish to alter the `env` of a layer you must update it's parent dataset - see _Update a Dataset_.
+Note: it is not possible to update the `env` property of a layer this way. If you wish to alter the `env` of a layer you must update its parent dataset - see [Updating a Dataset](#updating-a-dataset).
 
 ## Delete a Layer
 

--- a/source/includes/api/_layer.md
+++ b/source/includes/api/_layer.md
@@ -251,7 +251,9 @@ staticImageConfig |                                                             
 iso               |                                                               Isos to which the layer belongs                                                               |  Array |                                         BRA, ES |       No
 dataset           |                                                                     UuId of the dataset                                                                     |   Text |                                 Uuid of Dataset |       No
 protected         |                                            If it's a protected layer (not is possible to delete if it's true)                                               |   Boolean |                                 true-false |       No
+env         |                                            Environment of the Layer. Set to 'production' by default                                               |   String |                                 Valid string |       No
 
+It is possible to create a layer that has a different `env` property to it's parent dataset. 
 
 > To create a layer, you have to do a POST request with the following body:
 
@@ -317,6 +319,7 @@ curl -X PATCH https://api.resourcewatch.org/v1/dataset/<dataset_id>/layer/<layer
    }
 }'
 ```
+Note: it is not possible to update the `env` property of a layer this way. If you wish to alter the `env` of a layer you must update it's parent dataset - see _Update a Dataset_.
 
 ## Delete a Layer
 

--- a/source/includes/api/_widget.md
+++ b/source/includes/api/_widget.md
@@ -322,6 +322,9 @@ template     |           If it's a template            | Boolean |              
 default      |       If it's default for dataset       | Boolean |                                    true - false |       No
 layerId      |   UuId of the relationship with layer   |    Text |                                   Uuid of layer |       No
 dataset      |           UuId of the dataset           |    Text |                                 Uuid of Dataset |       No
+env         |                                            Environment of the Widget. Set to 'production' by default                                               |   String |                                 Valid string |       No
+
+It is possible to create a widget that has a different `env` property to it's parent dataset. 
 
 > To create a widget, you have to do a POST request with the following body:
 

--- a/source/includes/api/_widget.md
+++ b/source/includes/api/_widget.md
@@ -324,7 +324,7 @@ layerId      |   UuId of the relationship with layer   |    Text |              
 dataset      |           UuId of the dataset           |    Text |                                 Uuid of Dataset |       No
 env         |                                            Environment of the Widget. Set to 'production' by default                                               |   String |                                 Valid string |       No
 
-It is possible to create a widget that has a different `env` property to it's parent dataset. 
+It is possible to create a widget that has a different `env` property to its parent dataset. 
 
 > To create a widget, you have to do a POST request with the following body:
 


### PR DESCRIPTION
### Dataset
 - Updating env on a dataset is possible
 - It propagates that env change to all associated layers and widgets
### Layer
- It's not possible to update the env of a layer on it's own
- You can create a layer with a different env that the one of the associated dataset. If no env is provided, "production" is used
### Widget
- You can update the env of an individual widget
- You can create a widget with a different env that the one of the associated dataset. If no env is provided, "production" is used