### PR TITLE
Update subscription docs to take into consideration POSTing to web-hooks

### DIFF
--- a/source/includes/api/_subscriptions.md
+++ b/source/includes/api/_subscriptions.md
@@ -39,7 +39,7 @@ name          |                               Name                              
 application   | Application of the subscription. Set to 'gfw' by default          |      gfw, rw, prep
 language      | Language of the subscriptions (used to select the email template) | en, es, fr, pt, zh
 resource      | Details on the resource that will be notified for the subscription. |           Object
--- type       | The type of resource to notify. <br>If `EMAIL`, an email is sent to the email saved in the resource content. <br>If `URL`, a POST is requested to the web-hook URL in the resource content. | String
+-- type       | The type of resource to notify. If `EMAIL`, an email is sent to the email saved in the resource content. If `URL`, a POST is requested to the web-hook URL in the resource content. | String
 -- content    |  The email or URL that will be notified (according to the type).  |             String
 datasets      |               Array of datasets of the subscription               |              Array
 datasetsQuery |              Subscriptions to subscribable datasets               |              Array

--- a/source/includes/api/_subscriptions.md
+++ b/source/includes/api/_subscriptions.md
@@ -38,9 +38,9 @@ Field         |                            Description                          
 name          |                               Name                                |               Text
 application   | Application of the subscription. Set to 'gfw' by default          |      gfw, rw, prep
 language      | Language of the subscriptions (used to select the email template) | en, es, fr, pt, zh
-resource      |   This field contains the subscription is of type email or hook   |             Object
--- type       |                               Type                                |       EMAIL or URL
--- content    |                           Email or url                            |               Text
+resource      | Details on the resource that will be notified for the subscription. |           Object
+-- type       | The type of resource to notify. <br>If `EMAIL`, an email is sent to the email saved in the resource content. <br>If `URL`, a POST is requested to the web-hook URL in the resource content. | String
+-- content    |  The email or URL that will be notified (according to the type).  |             String
 datasets      |               Array of datasets of the subscription               |              Array
 datasetsQuery |              Subscriptions to subscribable datasets               |              Array
 -- id         |                           Id of dataset                           |           ObjectId


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170649158

## What does this PR add?

This PR updates the docs for the subscription resource with focus on the support for POSTing to web-hooks.

@tiagojsag I added this info in the fields table on the "Create Subscription" section. Do you think that we need a new section detailing more on the web-hooks? (for instance, describing what data is sent in the body of the web-hook POST)