### PR TITLE
Add notice with TOS and attribution requirements

### DIFF
--- a/source/index-rw.html.md
+++ b/source/index-rw.html.md
@@ -46,3 +46,7 @@ search: true
 # Introduction
 
 Welcome to the Resource Watch API Documentation
+
+<aside class="notice">
+  All use of the Resource Watch API is subject to the Resource Watch <a href="https://resourcewatch.org/terms-of-service" target="_blank">Terms of Service</a> and <a href="https://resourcewatch.org/api-attribution-requirements" target="_blank">API Attribution Requirements</a>.
+</aside>

--- a/source/index-rw.html.md
+++ b/source/index-rw.html.md
@@ -48,5 +48,5 @@ search: true
 Welcome to the Resource Watch API Documentation
 
 <aside class="notice">
-  All use of the Resource Watch API is subject to the Resource Watch <a href="https://resourcewatch.org/terms-of-service" target="_blank">Terms of Service</a> and <a href="https://resourcewatch.org/api-attribution-requirements" target="_blank">API Attribution Requirements</a>.
+  All use of the Resource Watch API is governed by the Resource Watch <a href="https://resourcewatch.org/terms-of-service" target="_blank">Terms of Service</a> and <a href="https://resourcewatch.org/api-attribution-requirements" target="_blank">API Attribution Requirements</a>.
 </aside>


### PR DESCRIPTION
Add a notice at the top of the API docs telling users that all use is subject to the API terms of use and attribution requirements.