### PR TITLE
Widget concept documentation

### DIFF
--- a/source/includes/concept/_widget.md
+++ b/source/includes/concept/_widget.md
@@ -1,17 +1,19 @@
 ## Widget
 
-You have fetched your data from your [dataset](#dataset) using [queries](#query). And you know how to build custom visualizations for geospatial data using [layers](#layer). Yet, sometimes your data is not geo-located, and you want to build a plain graphical representation of it: this is when **widgets** come in handy.
+You have fetched your data from your [dataset](#dataset) using [queries](#query). And you know how to build custom visualizations for geospatial data using [layers](#layer). Yet, sometimes you want to build a plain graphical representation of your data - whether it is geo-referenced or not: this is when **widgets** come in handy.
 
 A **widget** is a visual specification of how to style and render the data of a dataset (think pie, bar or line charts).
 
 As with layers, each widget has a single dataset associated with it, and a dataset can be associated with many widgets. You can represent the same data in different ways by creating different widgets for the same dataset. The same widget can store independent configuration values for each RW API based application. It can also contain the required configuration for rendering the same visualization using different rendering tools.
 
-Like layers, the widget itself does not interact with the dataset data. You can either use the widget's `queryUrl` field to store the query to get the widget's data or store it inside the free form `widgetConfig` object. In any of these cases, it is your responsibility as an API user to query the data that will be used for rendering the widget.
+However, this association with the dataset is only for organizational purposes. As such, like in the case of layers, the widget itself does not interact with the dataset data. You can either use the widget's `queryUrl` field to store the query to get the widget's data or store it inside the free form `widgetConfig` object. In any of these cases, it is your responsibility as an API user to query the data that will be used for rendering the widget.
 
 In the [widget endpoint documentation](#widget7), you can get into more detail on how you can manage widgets.
 
 ### Widget configuration using Vega grammar
 
-As in the case of layers (where many fields are free-form), the RW API does not apply any restriction to whatever is saved in the widget configuration field (`widgetConfig`). This allows for a very high level of flexibility for users, but has the downside of making it harder to document how to use widgets.
+As in the case of layers (where many fields are free-form), the RW API does not apply any restriction to the data saved in the widget configuration field (`widgetConfig`). This allows for a very high level of flexibility for users but has the downside of making it harder to document how to use widgets.
 
-However, contrary to what happens with layers, many of the existing widgets base themselves in the [Vega grammar](https://github.com/vega/vega) for configuring its graphical representations. Vega is a visualization grammar, a declarative format for creating interactive visualization designs. You can then use a chart library that supports the Vega grammar (such as [d3.js](https://d3js.org/)) to render the widget and obtain your graphical representation.
+However, the existing widgets' standard approach for building widget configuration objects is using [Vega grammar](https://github.com/vega/vega). Vega is a visualization grammar, a declarative format for creating interactive visualization designs. You can then use a chart library that supports Vega grammar syntax (such as [d3.js](https://d3js.org/)) to render the widget and get your graphical representation.
+
+Please note that, in any case, you can use whatever configuration format you wish since the `widgetConfig` field is free-form.

--- a/source/includes/concept/_widget.md
+++ b/source/includes/concept/_widget.md
@@ -6,7 +6,7 @@ A **widget** is a visual specification of how to style and render the data of a 
 
 As with layers, each widget has a single dataset associated with it, and a dataset can be associated with many widgets. You can represent the same data in different ways by creating different widgets for the same dataset. The same widget can store independent configuration values for each RW API based application. It can also contain the required configuration for rendering the same visualization using different rendering tools.
 
-However, this association with the dataset is only for organizational purposes. As such, like in the case of layers, the widget itself does not interact with the dataset data. You can either use the widget's `queryUrl` field to store the query to get the widget's data or store it inside the free form `widgetConfig` object. In any of these cases, it is your responsibility as an API user to query the data that will be used for rendering the widget.
+However, this association between widgets and datasets is only for organizational purposes. As such, like in the case of layers, the widget itself does not interact with the dataset data. You can either use the widget's `queryUrl` field to store the query to get the widget's data or store it inside the free form `widgetConfig` object. In any of these cases, it is your responsibility as an API user to query the data that will be used for rendering the widget.
 
 In the [widget endpoint documentation](#widget7), you can get into more detail on how you can manage widgets.
 

--- a/source/includes/concept/_widget.md
+++ b/source/includes/concept/_widget.md
@@ -1,0 +1,17 @@
+## Widget
+
+You have fetched your data from your [dataset](#dataset) using [queries](#query). And you know how to build custom visualizations for geospatial data using [layers](#layer). Yet, sometimes your data is not geo-located, and you want to build a plain graphical representation of it: this is when **widgets** come in handy.
+
+A **widget** is a visual specification of how to style and render the data of a dataset (think pie, bar or line charts).
+
+As with layers, each widget has a single dataset associated with it, and a dataset can be associated with many widgets. You can represent the same data in different ways by creating different widgets for the same dataset. The same widget can store independent configuration values for each RW API based application. It can also contain the required configuration for rendering the same visualization using different rendering tools.
+
+Like layers, the widget itself does not interact with the dataset data. You can either use the widget's `queryUrl` field to store the query to get the widget's data or store it inside the free form `widgetConfig` object. In any of these cases, it is your responsibility as an API user to query the data that will be used for rendering the widget.
+
+In the [widget endpoint documentation](#widget7), you can get into more detail on how you can manage widgets.
+
+### Widget configuration using Vega grammar
+
+As in the case of layers (where many fields are free-form), the RW API does not apply any restriction to whatever is saved in the widget configuration field (`widgetConfig`). This allows for a very high level of flexibility for users, but has the downside of making it harder to document how to use widgets.
+
+However, contrary to what happens with layers, many of the existing widgets base themselves in the [Vega grammar](https://github.com/vega/vega) for configuring its graphical representations. Vega is a visualization grammar, a declarative format for creating interactive visualization designs. You can then use a chart library that supports the Vega grammar (such as [d3.js](https://d3js.org/)) to render the widget and obtain your graphical representation.

--- a/source/index-aqueduct.html.md
+++ b/source/index-aqueduct.html.md
@@ -14,6 +14,8 @@ includes:
   - concept/intro
   - concept/dataset
   - concept/query
+  - concept/layer
+  - concept/widget
   - api/authentication
   - api/contact
   - api/collections

--- a/source/index-gfw.html.md
+++ b/source/index-gfw.html.md
@@ -14,6 +14,8 @@ includes:
   - concept/intro
   - concept/dataset
   - concept/query
+  - concept/layer
+  - concept/widget
   - api/authentication
   - api/contact
   - api/collections

--- a/source/index-rw.html.md
+++ b/source/index-rw.html.md
@@ -15,6 +15,7 @@ includes:
   - concept/dataset
   - concept/query
   - concept/layer
+  - concept/widget
   - api/authentication
   - api/contact
   - api/collections

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -14,6 +14,8 @@ includes:
   - concept/intro
   - concept/dataset
   - concept/query
+  - concept/layer
+  - concept/widget
   - api/authentication
   - api/contact
   - api/collections


### PR DESCRIPTION
## Summary

This PR refers to [GTC-278](https://gfw.atlassian.net/browse/GTC-278). It adds a new section to the concept docs regarding **Widgets**.

## Testing instructions

If you feel like deep-diving into the contents of the PR, follow the steps below:

1. Clone the documentation repository and follow the [installation instructions on the README](https://github.com/resource-watch/doc-api#installation-and-usage).
2. Checkout the branch of this PR: `docs/widget-concept-docs`
3. Read the added concept docs for **widgets**.