### PR TITLE
Reintroduce center-column CSS rule for tutorials.

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -694,3 +694,23 @@ html, body {
 .copy-clipboard:hover {
   opacity: 0.8;
 }
+
+
+/*
+See Slate Issue 855 for a suggestions about how to get code blocks in the center column rather than always in the right column.
+https://github.com/slatedocs/slate/issues/855#issuecomment-337706179
+*/
+.content {
+  .center-column + pre {
+    position: static;
+    float: none;
+    clear: none;
+    margin: 0 28px;
+    left: 0;
+    margin-right: $examples-width !important;
+    width: 45% !important;     // May need to adjust this
+
+  }
+}
+
+


### PR DESCRIPTION
Commit d5b1fca53c9a6318d7287d44121674335aeadb5d broke the custom CSS
used in the tutorials (see [an example](https://resource-watch.github.io/doc-api/tutorials.html#software-specification) - the code should be in the middle column). This commit replaces that custom CSS.

I have not been able to test this since it looks like the ruby version required was updated at some some point and v2.4.1, which I had been using is no longer accepted.

It should build though, based on my experience.

