### PR TITLE
Update user management documentation after Okta migration

### DIFF
--- a/source/developer.html.md
+++ b/source/developer.html.md
@@ -23,6 +23,7 @@ includes:
   - dev/microservices
   - dev/areas_notification_emails
   - dev/subscriptions
+  - dev/user_management
   - dev/graph
 
 logo: logo-rw.png

--- a/source/includes/api/_dashboard.md
+++ b/source/includes/api/_dashboard.md
@@ -88,7 +88,7 @@ name           | Filter dashboards by name (partial matches and case-insensitive
 published      | Filter dashboards by publishing status (true, false).                             | Boolean
 private        | Filter dashboards by private status (true, false).                                | Boolean
 user           | Filter dashboards by author user id.                                              | Text
-user.role      | The role of the user who created the dashboard. If the requesting user does not have the ADMIN role, this filter is ignored. | `ADMIN`, `MANAGER` or `USER`
+user.role      | The role of the user who created the dashboard. If the requesting user does not have the ADMIN role, this filter is ignored. **Please keep in mind that, due to the limitations of the [underlying endpoint used to find user ids by role](developer.html#finding-user-ids-by-role), the performance of the request while using this filter might be degraded.** | `ADMIN`, `MANAGER` or `USER`
 application    | The application to which the dashboard belongs. Read more about this field [here](concepts.html#applications). | Text (single value)
 is-highlighted | Filter dashboards by highlighted ones (true,false).                               | Boolean
 is-featured    | Filter dashboards by featured ones (true,false).                                  | Boolean
@@ -194,6 +194,8 @@ curl -X GET https://api.resourcewatch.org/v1/dashboard?includes=user
 Loads the name and email address of the owner of the dashboard. If you request this issue as an authenticated user with ADMIN role, you will additionally get the owner's role.
 
 If the data is not available (for example, the user has since been deleted), no `user` property will be added to the layer object.
+
+**Please keep in mind that, due to the limitations of the [underlying endpoint used to find users by ids](developer.html#finding-users-by-ids), the performance of the request while including user information might be degraded.**
 
 ## Getting a dashboard by its ID
 

--- a/source/includes/api/_dataset.md
+++ b/source/includes/api/_dataset.md
@@ -171,7 +171,7 @@ clonedHost.hostPath |                                                           
 widgetRelevantProps |                                                                         | Array       | any valid text
 layerRelevantProps |                                                                          | Array       | any valid text
 subscribable   | If the dataset is subscribable (i.e. contains a non-empty object in the `subscribable` field) | Boolean     | `true` or `false`
-user.role      | Filter results by the role of the owner of the dataset. If the requesting user does not have the ADMIN role, this filter is ignored. | String      | `ADMIN`, `MANAGER` or `USER`
+user.role      | Filter results by the role of the owner of the dataset. If the requesting user does not have the ADMIN role, this filter is ignored. **Please keep in mind that, due to the limitations of the [underlying endpoint used to find user ids by role](developer.html#finding-user-ids-by-role), the performance of the request while using this filter might be degraded.** | String      | `ADMIN`, `MANAGER` or `USER`
 vocabulary[name]| Filter returned datasets by vocabulary tags. Does not support regexes.       | String      | any valid text
 collection     | Filter returned datasets collection id. Does not support regexes.            | String      | any valid text
 favourite      | Filter by favourited datasets. See [this section](reference.html#favorites) for more info. Does not support regexes. | String      | any valid text
@@ -295,7 +295,7 @@ When fetching datasets, you can request additional entities to be loaded. The fo
 * `layer` - loads all layers associated with each dataset.
 * `vocabulary` - loads all vocabulary entities associated with each dataset.
 * `metadata` - loads all metadata associated with each dataset.
-* `user` - loads the name, email address and role of the author of the dataset. If you do not issue this request as an `ADMIN` user, or if no user data is available, the `user` object will be empty.
+* `user` - loads the name, email address and role of the author of the dataset. If you do not issue this request as an `ADMIN` user, or if no user data is available, the `user` object will be empty. **Please keep in mind that, due to the limitations of the [underlying endpoint used to find users by ids](developer.html#finding-users-by-ids), the performance of the request while including user information might be degraded.**
 
 **Note:** If you include related entities (e.g. layers) with query filters, the filters will not cascade to the related entities.
 

--- a/source/includes/api/_layer.md
+++ b/source/includes/api/_layer.md
@@ -313,7 +313,7 @@ The layer list endpoint provides a wide range of filters that you can use to tai
 
 - `id`
 - `userName`
-- `userRole`: filtering by the role of the owning user can be done using the `user.role` query argument. If the requesting user does not have the ADMIN role, this filter is ignored.
+- `userRole`: filtering by the role of the owning user can be done using the `user.role` query argument. If the requesting user does not have the ADMIN role, this filter is ignored. **Please keep in mind that, due to the limitations of the [underlying endpoint used to find user ids by role](developer.html#finding-user-ids-by-role), the performance of the request while using this filter might be degraded.**
 - Filtering by fields of type `Object` is not supported.
 
 Additionally, you can use the following filters:
@@ -440,6 +440,8 @@ Loads all vocabulary entities associated with each layer. Internally this uses t
 Loads the name and email address of the author of the layer. If you request this issue as an authenticated user with `ADMIN` role, you will additionally get the author's role.
 
 If the data is not available (for example, the user has since been deleted), no `user` property will be added to the layer object.
+
+**Please keep in mind that, due to the limitations of the [underlying endpoint used to find users by ids](developer.html#finding-users-by-ids), the performance of the request while including user information might be degraded.**
 
 ```shell
 curl -X GET "https://api.resourcewatch.org/v1/layer?includes=user"

--- a/source/includes/api/_topic.md
+++ b/source/includes/api/_topic.md
@@ -90,6 +90,8 @@ Loads the name and email address of the author of the topic. If you request this
 
 If the data is not available (for example, the user has since been deleted), no `user` property will be added to the layer object.
 
+**Please keep in mind that, due to the limitations of the [underlying endpoint used to find users by ids](developer.html#finding-users-by-ids), the performance of the request while including user information might be degraded.**
+
 ```shell
 curl -X GET https://api.resourcewatch.org/v1/topic?includes=user
 ```

--- a/source/includes/api/_user_management.md
+++ b/source/includes/api/_user_management.md
@@ -418,7 +418,7 @@ curl -X GET "https://api.resourcewatch.org/auth/user?strategy=cursor"
             "createdAt": "2021-03-24T09:19:25.000Z",
             "updatedAt": "2021-03-26T09:54:08.000Z",
             "role": "USER",
-            "provider": "facebook",
+            "provider": "local",
             "extraUserData": { "apps": ["gfw"] }
         },
         {...},

--- a/source/includes/api/_widget.md
+++ b/source/includes/api/_widget.md
@@ -263,7 +263,7 @@ The widget list endpoint provides a wide range of filters that you can use to ta
 
 - `id`
 - `userName`
-- `userRole`: filtering by the role of the owning user can be done using the `user.role` query argument.
+- `userRole`: filtering by the role of the owning user can be done using the `user.role` query argument. **Please keep in mind that, due to the limitations of the [underlying endpoint used to find user ids by role](developer.html#finding-user-ids-by-role), the performance of the request while using this filter might be degraded.**
 
 Additionally, you can use the following filters:
 
@@ -414,6 +414,7 @@ curl -X GET "https://api.resourcewatch.org/v1/widget?includes=user"
 
 Loads the name and email address of the author of the widget. If the user issuing the request has role `ADMIN`, the response will also display the role of the widget's author. If the data is not available (for example, the user has since been deleted), no `user` property will be added to the widget object.
 
+**Please keep in mind that, due to the limitations of the [underlying endpoint used to find users by ids](developer.html#finding-users-by-ids), the performance of the request while including user information might be degraded.**
 
 #### Include Metadata
 

--- a/source/includes/concept/_pagination.md
+++ b/source/includes/concept/_pagination.md
@@ -95,5 +95,4 @@ The following endpoints adhere to the pagination conventions defined above:
 * [Datasets service](reference.html#dataset)
 * [Layers service](reference.html#layer)
 * [Tasks service](reference.html#tasks)
-* [Users service](reference.html#user-management)
 * [Widgets service](reference.html#widget)

--- a/source/includes/dev/_user_management.md
+++ b/source/includes/dev/_user_management.md
@@ -1,0 +1,81 @@
+# User Management
+
+When communicating with the Authorization microservice from other microservices, you have access to additional endpoints that are not available when using the public API. This section details these endpoints.
+
+
+## Finding users by ids
+
+```shell
+curl -X POST https://api.resourcewatch.org/auth/user/find-by-ids \
+-H "Authorization: Bearer <your-token>"
+-H "Content-Type: application/json"  -d \
+ '{ "ids": ["5e4d273dce77c53768bc24f9"] }'
+```
+
+> Example response:
+
+```json
+
+{
+    "data": [
+        {
+            "id": "5e4d273dce77c53768bc24f9",
+            "_id": "5e4d273dce77c53768bc24f9",
+            "email": "your@email.com",
+            "name": "",
+            "createdAt": "2021-03-24T09:19:25.000Z",
+            "updatedAt": "2021-03-26T09:54:08.000Z",
+            "role": "USER",
+            "provider": "local",
+            "extraUserData": { "apps": ["gfw"] }
+        }
+    ]
+}
+```
+
+You can find a set of users given their ids using the following endpoint. The ids of the users to find should be provided in the `ids` field of the request body.
+
+Please keep in mind that, under the hood, user management relies on Okta - for this reason, this endpoint depends on Okta's user search functionalities to find users by ids, and thus, inherits Okta's limitations. Okta limits user search at a maximum of 200 users per request, so in practice, this means we can only fetch pages of 200 users at a time. If you try to find, for instance, 400 users by ids, 2 requests will need to be made to Okta to fulfill this request, and as such, the performance of this endpoint might be degraded.
+
+**Due to these limitations, we advise only resort to this endpoint when you have no other valid alternative to find users. Even in that case, you might run into slow response times or, ultimately, not receiving the expected results when calling this endpoint.**
+
+## Finding user ids by role
+
+> Request structure to find user ids by role:
+
+```shell
+curl -X GET https://api.resourcewatch.org/auth/user/ids/:role \
+-H "Authorization: Bearer <your-token>"
+```
+
+> Example request to find user ids of ADMIN users:
+
+```shell
+curl -X GET https://api.resourcewatch.org/auth/user/ids/ADMIN \
+-H "Authorization: Bearer <your-token>"
+```
+
+> Example response:
+
+```json
+
+{
+    "data": [
+        "5e4d273dce77c53768bc24f9",
+        "5e4d273dce77c53768bc24f8",
+        "5e4d273dce77c53768bc24f7",
+        "5e4d273dce77c53768bc24f6",
+        "5e4d273dce77c53768bc24f5",
+        "5e4d273dce77c53768bc24f4",
+        "5e4d273dce77c53768bc24f3"
+    ]
+}
+```
+
+You can find the ids of the users for a given role using the following endpoint. Valid roles include "USER", "MANAGER" and "ADMIN". The response includes the array of ids matching the role provided in the `data` field.
+
+Please keep in mind that, under the hood, user management relies on Okta - for this reason, this endpoint depends on Okta's user search functionalities to find users by role, and thus, inherits Okta's limitations. Okta limits user search at a maximum of 200 users per request, so in practice, this means we can only fetch pages of 200 users at a time. If you try to find, for instance, users for the "USER" role, since there's a high number of "USER" users, many requests will have to be made to Okta to fulfill this request. As such, the performance of this endpoint might be degraded.
+
+**Due to these limitations, we advise only resort to this endpoint when you have no other valid alternative to find users. Even in that case, you might run into slow response times or, ultimately, not receiving the expected results when calling this endpoint.**
+
+Also, please note that existing endpoints may rely on this endpoint to be able to fulfill their requests. This is the case of sorting or filtering datasets/widgets/layers by user role, for instance. As such, the performance of these endpoints may also be affected by the degradation of performance of this endpoint. 


### PR DESCRIPTION
This PR updates the documentation for user management after the migration to Okta has been completed. The changes done include:

- Update pagination for `GET users` endpoint, explaining the 2 supported pagination strategies (cursor and offset);
- Update callback endpoints for 3rd party login, since those are now handled by a single common endpoint;
- Removal of endpoints that are not supported anymore, since Okta takes care of those processes of user management for us;